### PR TITLE
Moved "mmcblk" device type handling to after partitioning has been done.

### DIFF
--- a/install_image.sh
+++ b/install_image.sh
@@ -85,11 +85,6 @@ function partition_format() {
          finished=0
       fi
    done
-  
-if [[ ${devicename:5:6} = "mmcblk" ]]
-then
-   devicename=$devicename"p"
-fi
 
    ##### Determine data device size in MiB and partition ###
    printf "\n${CYAN}Partitioning, & formatting storage device...${NC}\n"
@@ -119,6 +114,10 @@ fi
    printf "\npartition name = $devicename\n\n" >> /root/enosARM.log
    printf "\n${CYAN}Formatting storage device $devicename...${NC}\n"
    printf "\n${CYAN}If \"/dev/sdx contains a ext4 file system Labelled XXXX\" or similar appears, Enter: y${NC}\n\n\n"
+   if [[ ${devicename:5:6} = "mmcblk" ]]
+   then
+      devicename=$devicename"p"
+   fi
    case $devicemodel in
       OdroidN2 | RPi4) partname1=$devicename"1"
                        mkfs.fat $partname1   2>> /root/enosARM.log


### PR DESCRIPTION
Tested the updated script this evening. Because the appending of the "p" to the devicename happened before partitioning, the lsblk and parted commands failed:

```
[root@archiso image-install]# ./install_image.sh 

Partitioning, & formatting storage device...
./install_image.sh: line 97: ((: devicesize=/1048576: syntax error: operand expected (error token is "/1048576")

Partitioning storage device /dev/mmcblk0p...
lsblk: /dev/mmcblk0p: not a block device
parted: invalid option -- '1'
parted: invalid option -- 'M'
parted: invalid option -- 'i'
parted: invalid option -- 'B'
Usage: parted [-hlmsv] [-a<align>] [DEVICE [COMMAND [PARAMETERS]]...]
```

I just moved it to after the partitioning has been done but before the formatting of the newly created partitions, then it all worked well :+1: 
