### PR TITLE
Add arch-install-scripts packages to image-install.sh

### DIFF
--- a/install-image-V2.7.sh
+++ b/install-image-V2.7.sh
@@ -295,7 +295,7 @@ Main() {
     CYAN='\033[0;36m'
     NC='\033[0m' # No Color
 
-    pacman -S --noconfirm --needed libnewt  &>/dev/null # for whiplash dialog
+    pacman -S --noconfirm --needed libnewt &>/dev/null # for whiplash dialog
     pacman -S --noconfirm --needed arch-install-scripts
     _check_if_root
     _check_all_apps_closed

--- a/install-image-V2.7.sh
+++ b/install-image-V2.7.sh
@@ -295,7 +295,8 @@ Main() {
     CYAN='\033[0;36m'
     NC='\033[0m' # No Color
 
-    pacman -S --noconfirm --needed libnewt &>/dev/null # for whiplash dialog
+    pacman -S --noconfirm --needed libnewt  &>/dev/null # for whiplash dialog
+    pacman -S --noconfirm --needed arch-install-scripts
     _check_if_root
     _check_all_apps_closed
     _choose_device


### PR DESCRIPTION
genfstab command for the btrfs install requires arch-install-scripts package to be installed. 