### PR TITLE
Changed RPi disklabel to MBR/msdos

### DIFF
--- a/install-image-V2.7.sh
+++ b/install-image-V2.7.sh
@@ -9,10 +9,10 @@ _partition_OdroidN2() {
     mkpart primary 258MiB $DEVICESIZE"MiB" \
     quit
 }
-
+# RPi4b refuses to boot a GPT-formatted SD card
 _partition_RPi4() {
     parted --script -a minimal $DEVICENAME \
-    mklabel gpt \
+    mklabel msdos \
     unit MiB \
     mkpart primary fat32 2MiB 202MiB \
     mkpart primary $FILESYSTEMTYPE 202MiB $DEVICESIZE"MiB" \


### PR DESCRIPTION
RPi 4B doesn't seem to like booting from GPT sd cards. Changed RPi disklabel to MBR/msdos from gpt to create a bootable sdcard.