### PR TITLE
GitHub Releases html query and parse issue

### DIFF
--- a/install-image-V2.7.sh
+++ b/install-image-V2.7.sh
@@ -77,7 +77,7 @@ _install_RPi4_image() {
     local totalurl
     local exit_status
 
-    url=$(curl https://github.com/pudges-place/images/releases | grep "enos-image-.*/enosLinuxARM-rpi-aarch64-latest.tar.gz" | sed s'#^.*pudges-place#pudges-place#'g | sed s'#latest.tar.gz.*#latest.tar.gz#'g | head -n 1)
+    url=$(curl https://api.github.com/repos/pudges-place/images/releases | grep "enos-image-.*/enosLinuxARM-rpi-aarch64-latest.tar.gz" | sed s'#^.*pudges-place#pudges-place#'g | sed s'#latest.tar.gz.*#latest.tar.gz#'g | head -n 1)
     totalurl="https://github.com/"$url
     wget $totalurl
     exit_status=$?


### PR DESCRIPTION
The html parsing failed due to urlencoded html tags, so the script couldn't download the actual release.

Suggesting here, to query JSON GitHub API, worked for me.